### PR TITLE
updating to v1.0.0 of the quay.io/ukhomeofficedigital/openjdk8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/ukhomeofficedigital/openjdk8:v0.1.2
+FROM quay.io/ukhomeofficedigital/openjdk8:v1.0.0
 
 MAINTAINER Jon Shanks "jon.shanks@digital.homeoffice.gov.uk" 
 


### PR DESCRIPTION
 image: brings security patches and a fix for the yum and overlayfs rpmdb corruption issues
